### PR TITLE
Feature: select the AES-192 cipher for the P-384 curve by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,25 +17,31 @@ The ASN.1 support is only complete so far, as to support the listed algorithms b
 
 Supported Ciphers
 =================
+A list of supported curves was selected based on NIST SP 800-186 Draft.  Thus, for example, the
+Koblitz curves (`secpXXXk1` in SEC 2) are not supported by Golang and not recommended by NIST.
 
-    +------------------+-------+---------+
-    | Symmetric Cipher | Curve |   Hash  |
-    +------------------+-------+---------+
-    |     AES-128      | P-256 | SHA-256 |
-    +------------------+-------+---------+
-    |     AES-192      | P-384 | SHA-384 |
-    +------------------+-------+---------+
-    |     AES-256      | P-521 | SHA-512 |
-    +------------------+-------+---------+
-             
-Key derivation function used: NIST SP 800-65a Concatenation KDF.
+Note: If one wants to use the Koblitz curves with this package, their minimal implementation can be
+found in e.g. https://github.com/decred/dcrd/blob/master/dcrec/secp256k1/ellipticadaptor.go.
 
-Curve P224 isn't supported because it does not provide a minimum security
-level of AES128 with HMAC-SHA1. According to NIST SP 800-57, the security
-level of P224 is 112 bits of security. Symmetric ciphers use CTR-mode;
-message tags are computed using HMAC-<HASH> function.
+The default symmetric cipher and hash parameters are the following:
+    +-------+-------------+---------+--------------+
+    | Curve |    Cipher   |  Hash   |   Auth Tag   |
+    +-------+-------------+---------+--------------+
+    | P-256 | AES-128-CTR | SHA-256 | HMAC-SHA-256 |
+    +-------+-------------+---------+--------------+
+    | P-384 | AES-192-CTR | SHA-384 | HMAC-SHA-384 |
+    +-------+-------------+---------+--------------+
+    | P-521 | AES-256-CTR | SHA-512 | HMAC-SHA-512 |
+    +-------+-------------+---------+--------------+
 
-The CMAC support is currently not present.
+The P-224 curve is not supported. As per SEC 1 section 3.11 guidance it is too weak to protect
+sensitive data beyond 2030. The P-256 is currently the default curve supported by the Foundries.io
+LmP platform. So, we recommend to use P-256 default parameters from the above table unless you have
+a specific requirement for a stronger encryption strength.
+
+The key derivation function used: NIST SP 800-56c Concatenation KDF.
+
+The CMAC based message tag and the CBC cipher schema are currently not supported.
 
 Benchmark
 =========
@@ -60,20 +66,16 @@ See the LICENSE file for details.
 
 Reference
 =========
-* SEC (Standard for Efficient Cryptography) 1, version 2.0: Elliptic
-  Curve Cryptography; Certicom, May 2009.
-  http://www.secg.org/sec1-v2.pdf
-* GEC (Guidelines for Efficient Cryptography) 2, version 0.3: Test
-  Vectors for SEC 1; Certicom, September 1999.
-  http://read.pudn.com/downloads168/doc/772358/TestVectorsforSEC%201-gec2.pdf
-* NIST SP 800-56a: Recommendation for Pair-Wise Key Establishment Schemes
-  Using Discrete Logarithm Cryptography. National Institute of Standards
-  and Technology, May 2007.
-  http://csrc.nist.gov/publications/nistpubs/800-56A/SP800-56A_Revision1_Mar08-2007.pdf
-* Suite B Implementer’s Guide to NIST SP 800-56A. National Security
-  Agency, July 28, 2009.
-  http://www.nsa.gov/ia/_files/SuiteB_Implementer_G-113808.pdf
-* NIST SP 800-57: Recommendation for Key Management – Part 1: General
-  (Revision 3). National Institute of Standards and Technology, July
-  2012.
-  http://csrc.nist.gov/publications/nistpubs/800-57/sp800-57_part1_rev3_general.pdf
+* SEC 1 v2: Standards for Efficient Cryptography: Elliptic Curve Cryptography.
+  Certicom Research. May 2009. http://www.secg.org/sec1-v2.pdf
+* SEC 2 v2: Standards for Efficient Cryptography: Recommended Elliptic Curve Domain Parameters.
+  Certicom Research. January 2010. https://www.secg.org/sec2-v2.pdf
+* NIST SP 800-186 Draft: Recommendations for Discrete Logarithm-Based Cryptography:
+  Elliptic Curve Domain Parameters. National Institute of Standards and Technology, October 2019.
+  https://csrc.nist.gov/publications/detail/sp/800-186/draft
+* NIST SP 800-56a Rev 3: Recommendation for Pair-Wise Key Establishment Schemes Using Discrete
+  Logarithm Cryptography. National Institute of Standards and Technology, April 2018.
+  https://csrc.nist.gov/publications/detail/sp/800-56a/rev-3/final
+* NIST SP 800-56c Rev 2: Recommendation for Key-Derivation Methods in Key-Establishment Schemes.
+  National Institute of Standards and Technology. August 2020.
+  https://csrc.nist.gov/publications/detail/sp/800-56c/rev-2/final

--- a/ecies.go
+++ b/ecies.go
@@ -82,8 +82,7 @@ func GenerateKey(rand io.Reader, curve elliptic.Curve, params *ECIESParams) (prv
 	return
 }
 
-// MaxSharedKeyLength returns the maximum length of the shared key the
-// public key can produce.
+// MaxSharedKeyLength returns the maximum length of the shared key the public key can produce.
 func MaxSharedKeyLength(pub *PublicKey) int {
 	return (pub.Curve.Params().BitSize + 7) / 8
 }
@@ -130,7 +129,7 @@ func incCounter(ctr []byte) {
 	}
 }
 
-// NIST SP 800-56 Concatenation Key Derivation Function (see section 5.8.1).
+// NIST SP 800-56c Concatenation Key Derivation Function (see section 4.1).
 func concatKDF(hash hash.Hash, z, s1 []byte, kdLen int) (k []byte, err error) {
 	if s1 == nil {
 		s1 = make([]byte, 0)
@@ -158,8 +157,7 @@ func concatKDF(hash hash.Hash, z, s1 []byte, kdLen int) (k []byte, err error) {
 	return
 }
 
-// messageTag computes the MAC of a message (called the tag) as per
-// SEC 1, 3.5.
+// messageTag computes the MAC of a message (called the tag) as per SEC 1, 3.5.
 func messageTag(hash func() hash.Hash, km, msg, shared []byte) []byte {
 	mac := hmac.New(hash, km)
 	mac.Write(msg)
@@ -175,8 +173,7 @@ func generateIV(params *ECIESParams, rand io.Reader) (iv []byte, err error) {
 	return
 }
 
-// symEncrypt carries out CTR encryption using the block cipher specified in the
-// parameters.
+// symEncrypt carries out CTR encryption using the block cipher specified in the parameters.
 func symEncrypt(rand io.Reader, params *ECIESParams, key, m []byte) (ct []byte, err error) {
 	c, err := params.Cipher(key)
 	if err != nil {
@@ -195,8 +192,7 @@ func symEncrypt(rand io.Reader, params *ECIESParams, key, m []byte) (ct []byte, 
 	return
 }
 
-// symDecrypt carries out CTR decryption using the block cipher specified in
-// the parameters
+// symDecrypt carries out CTR decryption using the block cipher specified in the parameters
 func symDecrypt(rand io.Reader, params *ECIESParams, key, ct []byte) (m []byte, err error) {
 	c, err := params.Cipher(key)
 	if err != nil {
@@ -211,8 +207,7 @@ func symDecrypt(rand io.Reader, params *ECIESParams, key, ct []byte) (m []byte, 
 }
 
 // Encrypt encrypts a message using ECIES as specified in SEC 1, 5.1. If
-// the shared information parameters aren't being used, they should be
-// nil.
+// the shared information parameters aren't being used, they should be nil.
 func Encrypt(rand io.Reader, pub *PublicKey, m, s1, s2 []byte) (ct []byte, err error) {
 	params := pub.Params
 	if params == nil {

--- a/params.go
+++ b/params.go
@@ -1,7 +1,6 @@
 package ecies
 
-// This file contains parameters for ECIES encryption, specifying the
-// symmetric encryption and HMAC parameters.
+// Parameters for the ECIES encryption: the symmetric cipher and hash parameters.
 
 import (
 	"crypto"
@@ -14,8 +13,7 @@ import (
 	"hash"
 )
 
-// The default curve for this package is the NIST P256 curve, which
-// provides security equivalent to AES-128.
+// The default curve is the NIST P256 curve, which provides security equivalent to AES-128.
 var DefaultCurve = elliptic.P256()
 
 var (
@@ -31,12 +29,9 @@ type ECIESParams struct {
 	KeyLen    int                                // length of symmetric key
 }
 
-// Standard ECIES parameters:
-// * ECIES using AES128 and HMAC-SHA-256-16
-// * ECIES using AES256 and HMAC-SHA-256-32
-// * ECIES using AES256 and HMAC-SHA-384-48
-// * ECIES using AES256 and HMAC-SHA-512-64
-
+// Standard ECIES parameters selected according to SEC 1 sections 3.5 - 3.8.
+// They were also verified to be compatible with go-ethereum's ECIES encryption schemes.
+// Golang-to-SEC transform: P224=secp224r1, P256=secp256r1, P384=secp384r1, P521=secp521r1
 var (
 	ECIES_AES128_SHA256 = &ECIESParams{
 		Hash:      sha256.New,
@@ -73,8 +68,7 @@ func AddParamsForCurve(curve elliptic.Curve, params *ECIESParams) {
 	paramsFromCurve[curve] = params
 }
 
-// ParamsFromCurve selects parameters optimal for the selected elliptic curve.
-// Only the curves P256, P384, and P512 are supported.
+// Select parameters optimal for the given elliptic curve.
 func ParamsFromCurve(curve elliptic.Curve) (params *ECIESParams) {
 	return paramsFromCurve[curve]
 }

--- a/params.go
+++ b/params.go
@@ -54,12 +54,12 @@ var (
 		KeyLen:    32,
 	}
 
-	ECIES_AES256_SHA384 = &ECIESParams{
+	ECIES_AES192_SHA384 = &ECIESParams{
 		Hash:      sha512.New384,
 		hashAlgo:  crypto.SHA384,
 		Cipher:    aes.NewCipher,
 		BlockSize: aes.BlockSize,
-		KeyLen:    32,
+		KeyLen:    24,
 	}
 
 	ECIES_AES256_SHA512 = &ECIESParams{
@@ -73,7 +73,7 @@ var (
 
 var paramsFromCurve = map[elliptic.Curve]*ECIESParams{
 	elliptic.P256(): ECIES_AES128_SHA256,
-	elliptic.P384(): ECIES_AES256_SHA384,
+	elliptic.P384(): ECIES_AES192_SHA384,
 	elliptic.P521(): ECIES_AES256_SHA512,
 }
 

--- a/params.go
+++ b/params.go
@@ -46,14 +46,6 @@ var (
 		KeyLen:    16,
 	}
 
-	ECIES_AES256_SHA256 = &ECIESParams{
-		Hash:      sha256.New,
-		hashAlgo:  crypto.SHA256,
-		Cipher:    aes.NewCipher,
-		BlockSize: aes.BlockSize,
-		KeyLen:    32,
-	}
-
 	ECIES_AES192_SHA384 = &ECIESParams{
 		Hash:      sha512.New384,
 		hashAlgo:  crypto.SHA384,
@@ -85,19 +77,6 @@ func AddParamsForCurve(curve elliptic.Curve, params *ECIESParams) {
 // Only the curves P256, P384, and P512 are supported.
 func ParamsFromCurve(curve elliptic.Curve) (params *ECIESParams) {
 	return paramsFromCurve[curve]
-
-	/*
-		switch curve {
-		case elliptic.P256():
-			return ECIES_AES128_SHA256
-		case elliptic.P384():
-			return ECIES_AES256_SHA384
-		case elliptic.P521():
-			return ECIES_AES256_SHA512
-		default:
-			return nil
-		}
-	*/
 }
 
 // ASN.1 encode the ECIES parameters relevant to the encryption operations.


### PR DESCRIPTION
The umbracle/ecies package works just fine for the P-256 curve we currently use.

However, it uses different parameters for P-384 than go-etherium; which also differ from SEC 1 recommended values.
In addition, it makes misleading claims, gives incomplete info, and has dead links in the README.

This PR fixes all these problems to bring the package into the production ready grade.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>