### PR TITLE
Fixup: correct the ECIES for the P-521 curve as per SEC 1

### DIFF
--- a/ecies_test.go
+++ b/ecies_test.go
@@ -39,7 +39,6 @@ func TestKDF(t *testing.T) {
 	}
 }
 
-var skLen int
 var ErrBadSharedKeys = fmt.Errorf("ecies: shared keys don't match")
 
 // cmpPublic returns true if the two public keys represent the same pojnt.
@@ -78,7 +77,6 @@ func TestSharedKey(t *testing.T) {
 		fmt.Println(err.Error())
 		t.FailNow()
 	}
-	skLen = MaxSharedKeyLength(&prv1.PublicKey) / 2
 
 	prv2, err := GenerateKey(rand.Reader, DefaultCurve, nil)
 	if err != nil {
@@ -86,13 +84,13 @@ func TestSharedKey(t *testing.T) {
 		t.FailNow()
 	}
 
-	sk1, err := prv1.GenerateShared(&prv2.PublicKey, skLen, skLen)
+	sk1, err := prv1.GenerateShared(&prv2.PublicKey)
 	if err != nil {
 		fmt.Println(err.Error())
 		t.FailNow()
 	}
 
-	sk2, err := prv2.GenerateShared(&prv1.PublicKey, skLen, skLen)
+	sk2, err := prv2.GenerateShared(&prv1.PublicKey)
 	if err != nil {
 		fmt.Println(err.Error())
 		t.FailNow()
@@ -100,34 +98,6 @@ func TestSharedKey(t *testing.T) {
 
 	if !bytes.Equal(sk1, sk2) {
 		fmt.Println(ErrBadSharedKeys.Error())
-		t.FailNow()
-	}
-}
-
-// Verify that the key generation code fails when too much key data is
-// requested.
-func TestTooBigSharedKey(t *testing.T) {
-	prv1, err := GenerateKey(rand.Reader, DefaultCurve, nil)
-	if err != nil {
-		fmt.Println(err.Error())
-		t.FailNow()
-	}
-
-	prv2, err := GenerateKey(rand.Reader, DefaultCurve, nil)
-	if err != nil {
-		fmt.Println(err.Error())
-		t.FailNow()
-	}
-
-	_, err = prv1.GenerateShared(&prv2.PublicKey, skLen*2, skLen*2)
-	if err != ErrSharedKeyTooBig {
-		fmt.Println("ecdh: shared key should be too large for curve")
-		t.FailNow()
-	}
-
-	_, err = prv2.GenerateShared(&prv1.PublicKey, skLen*2, skLen*2)
-	if err != ErrSharedKeyTooBig {
-		fmt.Println("ecdh: shared key should be too large for curve")
 		t.FailNow()
 	}
 }
@@ -258,7 +228,7 @@ func BenchmarkGenSharedKeyP256(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		_, err := prv.GenerateShared(&prv.PublicKey, skLen, skLen)
+		_, err := prv.GenerateShared(&prv.PublicKey)
 		if err != nil {
 			fmt.Println(err.Error())
 			b.FailNow()


### PR DESCRIPTION
It appears that the go-ethereum and its derivatives only ever tested the P-256 and S-256 curves for ECIES. The tests for other curves are missing (apart from the params check). What's worse, the P-521 curve shared key generation panics with the current parameters, and also fail when unmarshalling the public key of the encrypted message inside Decrypt.

So, I made 2 commits to make the P-521 curve work correctly. See the commit messages for more context of each change.

The changed `GenerateShared` function still pass the test vectors in https://github.com/foundriesio/go-ecies/pull/4 which were generated using the previous implementation (including the P-521 curve). The reason why they pass for P-521 is because old GenerateShared tests ignored curve parameters and used a max key length. Ironically, tests did it the correct way; it's the `Encrypt/Decrypt` code which was passing wrong parameters.

Likewise, the `Decrypt` function passes the test vectors in https://github.com/foundriesio/go-ecies/pull/4 which were generated after fixing the `GenerateShared` function, but before fixing the `Decrypt` function. Actully, these tests fail for the P-521 curve without the second commit due to wrong unmarshalling in the original implementation.

Signed-off-by: Volodymyr Khoroz <volodymyr.khoroz@foundries.io>